### PR TITLE
Add possibility to sideload editormappings

### DIFF
--- a/Assets/Battlehub/RTEditor/Scripts/Editors/EditorsMap.cs
+++ b/Assets/Battlehub/RTEditor/Scripts/Editors/EditorsMap.cs
@@ -87,6 +87,10 @@ namespace Battlehub.RTEditor
                 Debug.LogError("Editors map is null");
             }
         }
+        
+        public static void AddMapping(Type type, int index, bool enabled, bool isPropertyEditor) {
+            m_map.Add(type, new EditorDescriptor(index, enabled, isPropertyEditor));
+        }
 
         public static bool IsObjectEditorEnabled(Type type)
         {


### PR DESCRIPTION
Allows me to EditorsMap.AddMapping(typeof(OriginOffset), 20, true, false); in another assembly.

Or is there a better way to do this?