### PR TITLE
Pull request: allow layouts with a root region without tabs

### DIFF
--- a/Assets/Battlehub/UIControls/DockPanels/Scripts/Region.cs
+++ b/Assets/Battlehub/UIControls/DockPanels/Scripts/Region.cs
@@ -914,7 +914,6 @@ namespace Battlehub.UIControls.DockPanels
                 if (this == m_root.RootRegion)
                 {
                     CanResize = true;
-                    IsHeaderVisible = true;
                 }
             }
 


### PR DESCRIPTION
I wanted to create a default layout with just one window (showing the scene). Other windows can be docked on the side but are not opened by default.

I am only showing one window ("the scene") and I don't want the user to be able to close that window. The "tab" however takes up unnecessary space. I found the option "IsHeaderVisible" = false.

I am defining the default layout for the runtime editor as follows (in an editor extension):

    WindowDescriptor sceneWd;
    GameObject sceneContent;
    bool isDialog;
    wm.CreateWindow(RuntimeWindowType.Scene.ToString(), out sceneWd, out sceneContent, out isDialog);

    LayoutInfo scenePanel = wm.CreateLayoutInfo(sceneContent.transform, sceneWd.Header, sceneWd.Icon);
    scenePanel.CanClose = false;
    scenePanel.CanDrag = false;
    scenePanel.IsHeaderVisible = false;`

It seems however that option "IsHeaderVisible = false" works fine in all cases *except* if you have only one window in your default layout. I think that is a bug.

It seems to be a special case in the code which always overrules the layout and makes the tabs visible for the root region. I don't understand why though as it works perfectly fine even if the root region doesn't show the tabs. Nothing breaks. All the docking of windows works just fine if the root region doesn't have tabs.

I was thinking, there must be a reason this line of code is there... Maybe the code is there for if you don't use layouts but add tabs manually. However, for me that also doesn't make sense as then I would expect the same behavior for other regions, not just for the root region. Why would some behavior be specific for adding tabs to one specific region?

So, I think it is safe to just remove the line.

That way the only place where "IsHeaderVisible" is written in the Region.cs file is line 1316:

    region.IsHeaderVisible = IsHeaderVisible;

which takes the value from the layout and thus does exactly what I would expect. The other place which just blindly overwrites the value for the root layout is removed in the pull request.

Let me know if you think the change is ok or not...