### PR TITLE
Pull request - allow semi-transparent foreground UI in scene window

### DIFF
--- a/Assets/Battlehub/HDRP/RTEditor/Resources/UIForeground.shader
+++ b/Assets/Battlehub/HDRP/RTEditor/Resources/UIForeground.shader
@@ -108,12 +108,6 @@
 				clip(color.a - 0.001);
 				#endif
 
-				if (color.a > 0.2)
-				{
-					color.a = 1.0;
-				}
-				
-
 				return color;
 			}
 			ENDCG

--- a/Assets/Battlehub/UniversalRP/RTEditor/Resources/UIForeground.shader
+++ b/Assets/Battlehub/UniversalRP/RTEditor/Resources/UIForeground.shader
@@ -108,12 +108,6 @@
 				clip(color.a - 0.001);
 				#endif
 
-				if (color.a > 0.2)
-				{
-					color.a = 1.0;
-				}
-				
-
 				return color;
 			}
 			ENDCG


### PR DESCRIPTION
I want to overlay a bit of information over the scene window, but transparency doesn't work as expected. I can only make the overlay transparent if I set the alpha very low. In all other case transparency is not applied.

**Technical:**
It looks like anything I put in the foreground UI for the scene window correctly makes it to the "foreground render texture" with the correct alpha. However, afterwards the material to render it on top of the rest removes the alpha. I didn't immediately see a reason for this, so removing it in this pull request.

Is there a reason for it?