### PR TITLE
Support for custom outline prepass materials

### DIFF
--- a/Assets/Battlehub/RTHandles/Outline/Scripts/Custom.meta
+++ b/Assets/Battlehub/RTHandles/Outline/Scripts/Custom.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4b99f595d4583d146967278b27e91c8f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Battlehub/RTHandles/Outline/Scripts/Custom/CustomOutlinePrepass.cs
+++ b/Assets/Battlehub/RTHandles/Outline/Scripts/Custom/CustomOutlinePrepass.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+
+namespace Battlehub.RTHandles
+{
+    /// <summary>
+    /// Default Implementation of ICustomOutlinePrepass.
+    /// Attach to a gameobject to use a custom material for rendering the outline
+    /// (e.g. when using vertex displacement or transparency in the material)
+    /// </summary>
+    public class CustomOutlinePrepass: MonoBehaviour, ICustomOutlinePrepass
+    {
+        public Renderer Renderer;
+        public Material PrepassMaterial;
+
+        public Renderer GetRenderer()
+        {
+            return Renderer;
+        }
+        
+        public Material GetOutlinePrepassMaterial()
+        {
+            return PrepassMaterial;
+        }
+    }
+}

--- a/Assets/Battlehub/RTHandles/Outline/Scripts/Custom/CustomOutlinePrepass.cs.meta
+++ b/Assets/Battlehub/RTHandles/Outline/Scripts/Custom/CustomOutlinePrepass.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4dfc7a5535d6550479a42bf43d1149b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Battlehub/RTHandles/Outline/Scripts/Custom/CustomOutlineRenderersCache.cs
+++ b/Assets/Battlehub/RTHandles/Outline/Scripts/Custom/CustomOutlineRenderersCache.cs
@@ -1,0 +1,70 @@
+using Battlehub.RTCommon;
+using Battlehub.UIControls.DockPanels;
+using Battlehub.RTHandles;
+using Battlehub.RTEditor;
+using UnityEngine;
+using System.Linq;
+using Battlehub.Utils;
+using System.Collections.Generic;
+
+namespace Battlehub.RTHandles
+{
+    public class CustomOutlineRenderersCache : EditorExtension, ICustomOutlineRenderersCache
+    {
+        private List<ICustomOutlinePrepass> rendererItems = new List<ICustomOutlinePrepass>();
+        private IRuntimeEditor editor;
+
+        protected override void OnEditorExist()
+        {
+            editor = IOC.Resolve<IRuntimeEditor>();
+            if (editor.IsOpened)
+            {
+                IOC.Register("CustomOutlineRenderersCache", (ICustomOutlineRenderersCache) this);
+
+                TryToAddRenderers(editor.Selection);
+                editor.Selection.SelectionChanged += OnRuntimeEditorSelectionChanged;
+            }
+        }
+
+        protected override void OnDestroy()
+        {
+            base.OnDestroy();
+            if (editor != null)
+            {
+                editor.Selection.SelectionChanged -= OnRuntimeEditorSelectionChanged;
+            }
+
+            IOC.Unregister("CustomOutlineRenderersCache", (ICustomOutlineRenderersCache) this);
+        }
+
+        private void OnRuntimeEditorSelectionChanged(Object[] unselectedObjects)
+        {
+            if (unselectedObjects != null)
+            {
+                ICustomOutlinePrepass[] renderers = unselectedObjects.Select(go => go as GameObject).Where(go => go != null).SelectMany(go => go.GetComponentsInChildren<ICustomOutlinePrepass>(true)).ToArray();
+                for(int i = 0; i < renderers.Length; ++i)
+                {
+                    rendererItems.Remove(renderers[i]);
+                }
+            }
+            TryToAddRenderers(editor.Selection);
+        }
+
+        private void TryToAddRenderers(IRuntimeSelection selection)
+        {
+            if (selection.gameObjects != null)
+            {
+                ICustomOutlinePrepass[] renderers = selection.gameObjects.Where(go => go != null).Select(go => go.GetComponent<ExposeToEditor>()).Where(e => e != null && e.ShowSelectionGizmo && !e.gameObject.IsPrefab() && (e.gameObject.hideFlags & HideFlags.HideInHierarchy) == 0).SelectMany(e => e.GetComponentsInChildren<ICustomOutlinePrepass>()).ToArray();
+                for (int i = 0; i < renderers.Length; ++i)
+                {
+                    ICustomOutlinePrepass renderer = renderers[i];
+                    rendererItems.Add(renderer);
+                }
+            }
+        }
+
+        public List<ICustomOutlinePrepass> GetOutlineRendererItems() {
+            return rendererItems;
+        }
+    }
+}

--- a/Assets/Battlehub/RTHandles/Outline/Scripts/Custom/CustomOutlineRenderersCache.cs.meta
+++ b/Assets/Battlehub/RTHandles/Outline/Scripts/Custom/CustomOutlineRenderersCache.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f680b88ed688f24e8be8c973694868c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Battlehub/RTHandles/Outline/Scripts/Custom/ICustomOutlinePrepass.cs
+++ b/Assets/Battlehub/RTHandles/Outline/Scripts/Custom/ICustomOutlinePrepass.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+namespace Battlehub.RTHandles
+{
+    /// <summary>
+    /// Interface to allow rendering "outline" selection in the runtime editor with a different material.
+    /// 
+    /// Material should render the full relevant area in opaque red rgba(1, 0, 0, 1)
+    /// </summary>
+    public interface ICustomOutlinePrepass {
+        Renderer GetRenderer();
+        Material GetOutlinePrepassMaterial();
+    }
+}

--- a/Assets/Battlehub/RTHandles/Outline/Scripts/Custom/ICustomOutlinePrepass.cs.meta
+++ b/Assets/Battlehub/RTHandles/Outline/Scripts/Custom/ICustomOutlinePrepass.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c8891f7d86223e4c81452b25f5b4995
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Battlehub/RTHandles/Outline/Scripts/Custom/ICustomOutlineRenderersCache.cs
+++ b/Assets/Battlehub/RTHandles/Outline/Scripts/Custom/ICustomOutlineRenderersCache.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Battlehub.RTHandles
+{
+    public interface ICustomOutlineRenderersCache {
+        List<ICustomOutlinePrepass> GetOutlineRendererItems();
+    }
+}

--- a/Assets/Battlehub/RTHandles/Outline/Scripts/Custom/ICustomOutlineRenderersCache.cs.meta
+++ b/Assets/Battlehub/RTHandles/Outline/Scripts/Custom/ICustomOutlineRenderersCache.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf011535f3b8b584d919d4dacd6109df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Battlehub/RTHandles/Outline/Scripts/OutlineManager.cs
+++ b/Assets/Battlehub/RTHandles/Outline/Scripts/OutlineManager.cs
@@ -115,6 +115,9 @@ namespace Battlehub.RTHandles
             {
                 Renderer[] renderers = unselectedObjects.Select(go => go as GameObject).Where(go => go != null).SelectMany(go => go.GetComponentsInChildren<Renderer>(true)).ToArray();
                 m_outlineEffect.RemoveRenderers(renderers);
+
+                ICustomOutlinePrepass[] customRenderers = unselectedObjects.Select(go => go as GameObject).Where(go => go != null).SelectMany(go => go.GetComponentsInChildren<ICustomOutlinePrepass>(true)).ToArray();
+                m_outlineEffect.RemoveRenderers(customRenderers);
             }
             TryToAddRenderers(selection);
         }
@@ -125,6 +128,9 @@ namespace Battlehub.RTHandles
             {
                 Renderer[] renderers = selection.gameObjects.Where(go => go != null).Select(go => go.GetComponent<ExposeToEditor>()).Where(e => e != null && e.ShowSelectionGizmo && !e.gameObject.IsPrefab() && (e.gameObject.hideFlags & HideFlags.HideInHierarchy) == 0).SelectMany(e => e.GetComponentsInChildren<Renderer>().Where(r => (r.gameObject.hideFlags & HideFlags.HideInHierarchy) == 0)).ToArray();
                 m_outlineEffect.AddRenderers(renderers);
+
+                ICustomOutlinePrepass[] customRenderers = selection.gameObjects.Where(go => go != null).Select(go => go.GetComponent<ExposeToEditor>()).Where(e => e != null && e.ShowSelectionGizmo && !e.gameObject.IsPrefab() && (e.gameObject.hideFlags & HideFlags.HideInHierarchy) == 0).SelectMany(e => e.GetComponentsInChildren<ICustomOutlinePrepass>()).ToArray();
+                m_outlineEffect.AddRenderers(customRenderers);
             }
         }
 


### PR DESCRIPTION
### Use Cases

1. In my scene I have some objects which have a vertex shader which displaces the vertices. When selecting this object in the editor, the selection outline does not show up correctly because the "outline prepass" material does not apply the same vertex displacement.

2. I also have some sprites in my scene. For Sprites, Unity generates a mesh, but this mesh does not really match the shape of the sprite. It looks like Unity tries to fit the shape as best as it can with very few vertices (so, very rough fit). E.g a circle sprite becomes something like an octagon, but for more complex sprites the generated mesh doesn't even look like the sprite anymore... Because the current outline shader does not take into account textures, sprites end up with this rather weird outline. Having a custom "outline prepass" material for these objects which takes into account transparency would solve the issue.

### How?

To make this vertex displacement & transparency show up, I want to have the outline for these objects rendered using a different material which also simply returns the color red, but correctly applies the displacement for the one object & transparency for the other object. These materials are really specific for these objects. Most objects are fine with the default prepass shader.

### Implementation notes.

In this pull-request I did the outline extension for URP and Default Renderer. I am only using URP. I tested that the URP implementation works and the "default renderer" implementation is very similar. For the default renderer implementation, I verified that it compiles, but didn't actually set up a project with default renderer with such a custom material. I committed the "Default Renderer" implementation separately for that reason (I can easily take it out of the pull-request).

Note: for URP, the component CustomOutlineRenderersCache needs to be added somewhere in the scene for it to work. I guess it should be part of the URPInit, but I didn't dare touching that prefab... For the "default renderer" implementation this component is not needed.

### How to use?

You can add a CustomOutlinePrepass or ICustomOutlinePrepass component to your objects to have them use a different outline prepass material.