### PR TITLE
Add support for configuration of default cursor

### DIFF
--- a/Assets/Battlehub/Utils/Scripts/CursorHelper.cs
+++ b/Assets/Battlehub/Utils/Scripts/CursorHelper.cs
@@ -14,12 +14,29 @@ namespace Battlehub.Utils
     public class CursorHelper
     {
         private object m_locker;
-        private Texture2D m_texutre;
+        private Texture2D m_texture;
 
         private readonly Dictionary<KnownCursor, Texture2D> m_knownCursorToTexture = new Dictionary<KnownCursor, Texture2D>();
         public void Map(KnownCursor cursorType, Texture2D texture)
         {
             m_knownCursorToTexture[cursorType] = texture;
+        }
+
+        private Texture2D m_defaultCursorTexture;
+        private Vector2 m_defaultCursorHotspot;
+        public Texture2D DefaultCursorTexture
+        {
+            get {return m_defaultCursorTexture;}
+        }
+        public Vector2 DefaultCursorHotspot
+        {
+            get {return m_defaultCursorHotspot;}
+        }
+        public void SetDefaultCursor(Texture2D texture, Vector2 hotspot)
+        {
+            m_defaultCursorTexture = texture;
+            m_defaultCursorHotspot = hotspot;
+            ResetCursor(null);
         }
 
         public void Reset()
@@ -57,14 +74,20 @@ namespace Battlehub.Utils
             if(texture != null)
             {
                 hotspot = new Vector2(texture.width * hotspot.x, texture.height * hotspot.y);
+            } else {
+                texture = DefaultCursorTexture;
+                if(texture != null)
+                {
+                    hotspot = new Vector2(texture.width * DefaultCursorHotspot.x, texture.height * DefaultCursorHotspot.y);
+                }
             }
 
             m_locker = locker;
-            if(m_texutre != texture)
+            if(m_texture != texture)
             {
                 Cursor.SetCursor(null, Vector2.zero, CursorMode.Auto);
                 Cursor.SetCursor(texture, hotspot, mode);
-                m_texutre = texture;
+                m_texture = texture;
             }
         }
 
@@ -74,12 +97,10 @@ namespace Battlehub.Utils
             {
                 return;
             }
-
-            m_texutre = null;
             m_locker = null;
-            Cursor.SetCursor(null, Vector2.zero, CursorMode.Auto);
-        }
 
+            SetCursor(null, DefaultCursorTexture, DefaultCursorHotspot, CursorMode.Auto);
+        }
     }
 
 }


### PR DESCRIPTION
### Use case
In the runtime editor most cursors can be configured. Some in the Appearance, some in the different prefabs. The only one cursor cannot be configured is the default cursor. CursorHelper.ResetCursor() always returns to the system cursor without any chance to customize its appearance. The system default is always used (null).

### How to use?
Default cursor can now be set using:
`Editor.CursorHelper.SetDefaultCursor(texture, hotspot)`